### PR TITLE
Added support for ints, uints and float32

### DIFF
--- a/colorjson.go
+++ b/colorjson.go
@@ -141,6 +141,15 @@ func (f *Formatter) marshalValue(val interface{}, buf *bytes.Buffer, depth int) 
 		f.marshalArray(v, buf, depth)
 	case string:
 		f.marshalString(v, buf)
+	case []string:
+		buf.WriteString("[")
+		for i, s := range v {
+			f.marshalString(s, buf)
+			if i != len(v) - 1 {
+				buf.WriteString(", ")
+			}
+		}
+		buf.WriteString("]")
 	case int:
 		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(int64(v), 10)))
 	case int8:

--- a/colorjson.go
+++ b/colorjson.go
@@ -141,10 +141,32 @@ func (f *Formatter) marshalValue(val interface{}, buf *bytes.Buffer, depth int) 
 		f.marshalArray(v, buf, depth)
 	case string:
 		f.marshalString(v, buf)
+	case int:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(int64(v), 10)))
+	case int8:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(int64(v), 10)))
+	case int16:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(int64(v), 10)))
+	case int32:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(int64(v), 10)))
+	case int64:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(v, 10)))
+	case uint:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(int64(v), 10)))
+	case uint8:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(int64(v), 10)))
+	case uint16:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(int64(v), 10)))
+	case uint32:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(int64(v), 10)))
+	case uint64:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatInt(int64(v), 10)))
+	case float32:
+		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatFloat(float64(v), 'f', -1, 64)))
 	case float64:
 		buf.WriteString(f.sprintColor(f.NumberColor, strconv.FormatFloat(v, 'f', -1, 64)))
 	case bool:
-		buf.WriteString(f.sprintColor(f.BoolColor, (strconv.FormatBool(v))))
+		buf.WriteString(f.sprintColor(f.BoolColor, strconv.FormatBool(v)))
 	case nil:
 		buf.WriteString(f.sprintColor(f.NullColor, null))
 	}


### PR DESCRIPTION
I added support for various `int` and `uint` types, as well as `float32`.

I understand that your library was targeting unmarshalled JSON structs, so this might not be in scope. I am using `colorjson` to pretty-print my structs for debugging purposes and noticed that since these types aren't implemented, they return as an empty string in the output.

Also, unsure if there's a better way to implement this; Golang doesn't seem to like grouping `int`/`uint` types together and then type casting, so I have to make a case for each. The other option would of course be to use `reflect` but it's quite a bit slower.