### PR TITLE
Handle Number type from encoding/json

### DIFF
--- a/colorjson.go
+++ b/colorjson.go
@@ -147,6 +147,8 @@ func (f *Formatter) marshalValue(val interface{}, buf *bytes.Buffer, depth int) 
 		buf.WriteString(f.sprintColor(f.BoolColor, (strconv.FormatBool(v))))
 	case nil:
 		buf.WriteString(f.sprintColor(f.NullColor, null))
+	case json.Number:
+		buf.WriteString(f.sprintColor(f.NumberColor, v.String()))
 	}
 }
 


### PR DESCRIPTION
Support json.Number type for round-tripping numbers with formatting
when decoded with [UseNumber](https://golang.org/pkg/encoding/json/#Decoder.UseNumber)

Fixes #4 