### PR TITLE
Add f.ObjectSeparator flag

### DIFF
--- a/colorjson.go
+++ b/colorjson.go
@@ -30,6 +30,7 @@ type Formatter struct {
 	NullColor       *color.Color
 	StringMaxLength int
 	Indent          int
+	ObjectSeparator bool
 	DisabledColor   bool
 	RawStrings      bool
 }
@@ -44,6 +45,7 @@ func NewFormatter() *Formatter {
 		StringMaxLength: 0,
 		DisabledColor:   false,
 		Indent:          0,
+		ObjectSeparator: true,
 		RawStrings:      false,
 	}
 }
@@ -63,13 +65,16 @@ func (f *Formatter) sprintColor(c *color.Color, s string) string {
 }
 
 func (f *Formatter) writeIndent(buf *bytes.Buffer, depth int) {
+	if f.Indent == 0 {
+		return
+	}
 	buf.WriteString(strings.Repeat(" ", f.Indent*depth))
 }
 
 func (f *Formatter) writeObjSep(buf *bytes.Buffer) {
 	if f.Indent != 0 {
 		buf.WriteByte('\n')
-	} else {
+	} else if f.ObjectSeparator {
 		buf.WriteByte(' ')
 	}
 }
@@ -100,7 +105,10 @@ func (f *Formatter) marshalMap(m map[string]interface{}, buf *bytes.Buffer, dept
 
 	for _, key := range keys {
 		f.writeIndent(buf, depth+1)
-		buf.WriteString(f.KeyColor.Sprintf("\"%s\": ", key))
+		buf.WriteString(f.KeyColor.Sprintf("\"%s\":", key))
+		if f.ObjectSeparator {
+			buf.WriteByte(' ')
+		}
 		f.marshalValue(m[key], buf, depth+1)
 		remaining--
 		if remaining != 0 {

--- a/colorjson.go
+++ b/colorjson.go
@@ -105,7 +105,8 @@ func (f *Formatter) marshalMap(m map[string]interface{}, buf *bytes.Buffer, dept
 
 	for _, key := range keys {
 		f.writeIndent(buf, depth+1)
-		buf.WriteString(f.KeyColor.Sprintf("\"%s\":", key))
+		buf.WriteString(f.KeyColor.Sprintf("\"%s\"", key))
+		buf.WriteByte(':')
 		if f.ObjectSeparator {
 			buf.WriteByte(' ')
 		}


### PR DESCRIPTION
With this flag set to `true` (which is the default) and `f.Indent = 0`, then the behaviour is as previous, eg.

```json
{ "a": 5, "b": [ 1, 2, 3 ], "c": { "d": "e" } }
```  

When `f.ObjectSeparator = false` and `f.Indent = 0`, it would render the object as:
```json
{"a":5,"b":[1,2,3],"c":{"d":"e"}}
```  